### PR TITLE
Added entry for bioinformatics and new field for useful software engineering tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Adapting [awesome-semantic-web](https://github.com/semantalytics/awesome-semanti
   - [Genomics](#genomics)
   - [Proteomics](#proteomics)
   - [Metabolomics](#metabolomics)
+- [Software Engineering](#software-engineering)
 - [Resources](#resources)
   - [Tutorials](#tutorials)
   - [Books & Courses](#books--courses)
@@ -83,6 +84,10 @@ More comprehensive lists can be found in the [Awesome-Rust-MachineLearning](http
 - [mzdeisotope](https://github.com/mobiusklein/mzdeisotope) — Algorithms for charge state deconvolution and deisotoping of mass spectra and feature maps.
 - [mass-fragment-index](https://github.com/mobiusklein/mass-fragment-index) — Data structures for large-scale searching of precursor-product collections suitable for fragment indices, spectral libraries, or similar data. Includes fast-to-search on-disk serialization.
 
+---
+
+## Software Engineering
+- [shadow-rs](https://github.com/baoyachi/shadow-rs) — A rust library that adds support for showing a project's `Cargo.toml` info at runtime. 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ More comprehensive lists can be found in the [Awesome-Rust-MachineLearning](http
 ---
 
 ## Bioinformatics
-
+- [sprocket](https://github.com/stjude-rust-labs/sprocket) — Bioinformatics workflow engine
 ### Genomics
 - [rust-bio](https://github.com/rust-bio/rust-bio) — Bioinformatics algorithms and data structures.
 - [rust-htslib](https://github.com/rust-bio/rust-htslib) — Bindings to HTSlib for BAM/CRAM/VCF.


### PR DESCRIPTION
I found a useful (and very large) project for running jobs in bioinformatics and added to the list. I also noticed there wasn't a section for software engineering tools that might be useful for data science, and one such has been added that allows for passing a crate's info (dependencies, build environment, etc) into the finished binary/software. This seems like it could be good for open science software to consider including in a project, even if the original source code is available. 